### PR TITLE
Fix hitbox of shapes

### DIFF
--- a/artsmart.css
+++ b/artsmart.css
@@ -281,7 +281,7 @@ background-color: rgb(0, 164, 214);
 }
 .art-image {
     display: block;
-    position: absolute;
+    position: relative;
     top: 0;
     left: 0;
     width: 100%;


### PR DESCRIPTION
Previously a 100x1 area in the top-left corner of the shape was used to perform hit-testing, most likely by mistake.

Now the entire image's surface is used. This should greatly improve the reliability of the trash can.